### PR TITLE
Bind address config option

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -13,7 +13,7 @@ module.exports = {
 
   server: {
     port: process.env.PORT || 8888,
-    bind: process.env.BIND,
+    bind: process.env.BIND || '127.0.0.1',
     httpsUpgrade: process.env.HTTPS_UPGRADE,
     httpsKeyPin: process.env.HTTPS_KEY_PIN,
     httpsKeyPinBackup: process.env.HTTPS_KEY_PIN_BACKUP

--- a/config/default.js
+++ b/config/default.js
@@ -13,6 +13,7 @@ module.exports = {
 
   server: {
     port: process.env.PORT || 8888,
+    bind: process.env.BIND,
     httpsUpgrade: process.env.HTTPS_UPGRADE,
     httpsKeyPin: process.env.HTTPS_KEY_PIN,
     httpsKeyPinBackup: process.env.HTTPS_KEY_PIN_BACKUP

--- a/src/index.js
+++ b/src/index.js
@@ -21,11 +21,14 @@ const log = require('winston');
 const config = require('config');
 const init = require('./app');
 
+//custom
+log.add(new log.transports.Console());
+
 (async () => {
   try {
     const app = await init();
-    app.listen(config.server.port, '::1');
-    log.info('app', `Listening on http://localhost:${config.server.port}`);
+    app.listen(config.server.port, config.server.bind);
+    log.info('app', `Listening on http://${config.server.bind}:${config.server.port}`);
   } catch (err) {
     log.error('app', 'Initialization failed!', err);
     throw err;

--- a/suse/sysconfig
+++ b/suse/sysconfig
@@ -21,6 +21,13 @@ LOG_LEVEL="info"
 #
 PORT=8085
 
+## Type: string
+## Default: ::1
+#
+# Address for the HTTP server to bind to
+#
+BIND="::1"
+
 ## Type: boolean
 ## Default: true
 #


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>

Allows for the bind address to be set in both the `.js` configuration as well as using SUSE's `sysconfig`.